### PR TITLE
Ventilation mode (balance/supply onlu/extract only) commands fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Revision history:
 * 0.5.4 : fix bug with registering devices
 * 0.5.5 : extra commands to send to the comfoconnect device
           get time added
+* 0.5.8 : ventilation mode commands fixed
 
 ## Test Script
 

--- a/lib/const.js
+++ b/lib/const.js
@@ -37,6 +37,10 @@ const comfoCommands = [
 
   {name: 'VENTMODE_SUPPLY',  code: '8415060100000000100e000001'},
   {name: 'VENTMODE_BALANCE', code: '85150601'},
+  {name: 'VENTMODE_SUPPLY_OFF', code: '85150601'},
+
+  {name: 'VENTMODE_EXTRACT',  code: '8415070100000000100e000001'},
+  {name: 'VENTMODE_EXTRACT_OFF', code: '85150701'},
 
   {name: 'TEMPPROF_NORMAL',  code: '8415030100000000ffffffff00'},
   {name: 'TEMPPROF_COOL',    code: '8415030100000000ffffffff01'},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-comfoairq",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "NodeJS Zehnder ComfoAirQ implementation",
   "main": "lib/comfoconnect.js",
   "keywords": [


### PR DESCRIPTION
@herrJones I've looked at how this is handled elsewhere and added 3 commands:
VENTMODE_SUPPLY_OFF (it's the same protobuf payload as VENTMODE_BALANCE, which I kept for backward compatibility)
VENTMODE_EXTRACT + VENTMODE_EXTRACT_OFF

[This](https://github.com/michaelarnauts/aiocomfoconnect/blob/master/aiocomfoconnect/comfoconnect.py#L269) hints that if you want to switch back to balanced, you should disable supply only and extract only.
So effectively VENTMODE_BALANCE should be VENTMODE_EXTRACT_OFF + VENTMODE_SUPPLY_OFF