### PR TITLE
Fix infinite loop when trying to reconnect

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -225,8 +225,12 @@ ComfoAirQBridge.prototype.transmit = async function (data) {
 
     this.sock.connect(this._settings.port, this._settings.comfoair);
 
-    while (!this.isconnected) {
+    while (!this.isconnected && !this.sock.destroyed) {
       await config.sleep(25);
+    }
+
+    if (!this.isconnected) {
+      return Promise.reject('bridge not connected')
     }
   }
 

--- a/lib/comfoconnect.js
+++ b/lib/comfoconnect.js
@@ -283,7 +283,7 @@ ComfoAirQ.prototype.StartSession = function (force) {
           if (cnt <= 0) {
             if (this._exec.reconnect == null) {
               this._exec.keepalive = null;
-              this._exec.reconnect = setTimeout(this._reconnect.bind(this), this._status.keepalive);
+              this._exec.reconnect = setTimeout(this._reconnect.bind(this), this._settings.keepalive);
             }
             
             reject('timeout connecting (1)');
@@ -291,14 +291,14 @@ ComfoAirQ.prototype.StartSession = function (force) {
       
           if (this._status.connected) {
             if (this._exec.keepalive == null) {
-              this._exec.keepalive = setTimeout(this._keepalive.bind(this), this._status.keepalive);
+              this._exec.keepalive = setTimeout(this._keepalive.bind(this), this._settings.keepalive);
               this._exec.reconnect = null;
             }
             resolve({});
           } else {
             if (this._exec.reconnect == null) {
               this._exec.keepalive = null;
-              this._exec.reconnect = setTimeout(this._reconnect.bind(this), this._status.keepalive);
+              this._exec.reconnect = setTimeout(this._reconnect.bind(this), this._settings.keepalive);
             }
             reject('timeout connecting (2)');
           }


### PR DESCRIPTION
Fixes issue #16 .

Only waits for connection success as long as the socket is still alive. Will cancel waiting once the socket is destroyed and enable another reconnection attempt. 